### PR TITLE
Update tutorial.md

### DIFF
--- a/documentation/site/api/tutorial.md
+++ b/documentation/site/api/tutorial.md
@@ -247,7 +247,7 @@ export class TutorialApp {
 <script lang="ts">
     import { browser } from "$app/environment";
     import { OBSPermissions, OBSPlugin } from "@omujs/obs";
-    import { Omu, OmuPermissions } from "@omujs/omu";
+    import { BrowserSession, Omu, OmuPermissions } from "@omujs/omu";
     import { TUTORIAL_APP, TUTORIAL_ASSET_APP, TutorialApp } from ".";
 
     // APIを触るのに必要なOmuオブジェクトを生成します


### PR DESCRIPTION
抜け落ちていた@omujs内のBrowserSessionのインポートの追加

## 内容

documentation/site/api/tutorial.mdのインポート記述の不足
`import { Omu, OmuPermissions } from "@omujs/omu";`
のところに`BrowserSession`を追加すると動作したので、追加しました。